### PR TITLE
更新帮助页面的词库描述

### DIFF
--- a/src/ImeWlConverterCore/ConstantString.cs
+++ b/src/ImeWlConverterCore/ConstantString.cs
@@ -8,7 +8,7 @@ namespace Studyzy.IMEWLConverter
     /// </summary>
     public static class ConstantString
     {
-        public const string BAIDU_SHOUJI = "百度手机";
+        public const string BAIDU_SHOUJI = "百度手机或Mac版百度拼音";
         public const string BAIDU_SHOUJI_ENG = "百度手机英文";
         public const string BAIDU_BDICT = "百度分类词库bdict";
         public const string BAIDU_BCD = "百度手机词库bcd";


### PR DESCRIPTION
原本的帮助页面里`bdpy`只对应**百度拼音**，但实际上 Mac 版百度输入法导出的用户词库也沿用了百度手机的词库格式。

**Mac版百度拼音（5.3）用户词库导出示例：**

苍白无力(cang|bai|wu|li) 54999
仓储服务(cang|chu|fu|wu) 55000