### PR TITLE
增加功能

### DIFF
--- a/src/IME WL Converter Win/Forms/FilterConfigForm.Designer.cs
+++ b/src/IME WL Converter Win/Forms/FilterConfigForm.Designer.cs
@@ -78,6 +78,8 @@ namespace Studyzy.IMEWLConverter
             this.cbxKeepPunctuation_ = new System.Windows.Forms.CheckBox();
             this.cbxKeepPunctuation = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.cbxKeepSpace_ = new System.Windows.Forms.CheckBox();
+            this.cbxKeepSpace = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.numWordLengthFrom)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numWordLengthTo)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numWordRankFrom)).BeginInit();
@@ -88,7 +90,7 @@ namespace Studyzy.IMEWLConverter
             // 
             // btnOK
             // 
-            this.btnOK.Location = new System.Drawing.Point(752, 431);
+            this.btnOK.Location = new System.Drawing.Point(752, 443);
             this.btnOK.Margin = new System.Windows.Forms.Padding(4);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(100, 29);
@@ -386,9 +388,9 @@ namespace Studyzy.IMEWLConverter
             this.cbxFilterFirstCJK.Location = new System.Drawing.Point(22, 431);
             this.cbxFilterFirstCJK.Margin = new System.Windows.Forms.Padding(4);
             this.cbxFilterFirstCJK.Name = "cbxFilterFirstCJK";
-            this.cbxFilterFirstCJK.Size = new System.Drawing.Size(224, 19);
+            this.cbxFilterFirstCJK.Size = new System.Drawing.Size(269, 19);
             this.cbxFilterFirstCJK.TabIndex = 20;
-            this.cbxFilterFirstCJK.Text = "首字位于中日韩统一表义符区";
+            this.cbxFilterFirstCJK.Text = "过滤首字非中日韩统一表义字符的词";
             this.cbxFilterFirstCJK.UseVisualStyleBackColor = true;
             // 
             // cbxKeepNumber_
@@ -419,6 +421,8 @@ namespace Studyzy.IMEWLConverter
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.cbxKeepSpace);
+            this.groupBox1.Controls.Add(this.cbxKeepSpace_);
             this.groupBox1.Controls.Add(this.cbxChsNumber);
             this.groupBox1.Controls.Add(this.cbxPrefixEnglish);
             this.groupBox1.Controls.Add(this.cbxKeepPunctuation_);
@@ -429,7 +433,7 @@ namespace Studyzy.IMEWLConverter
             this.groupBox1.Controls.Add(this.cbxKeepEnglish);
             this.groupBox1.Location = new System.Drawing.Point(423, 155);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(471, 234);
+            this.groupBox1.Size = new System.Drawing.Size(471, 269);
             this.groupBox1.TabIndex = 23;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "词条分段处理";
@@ -437,7 +441,7 @@ namespace Studyzy.IMEWLConverter
             // cbxChsNumber
             // 
             this.cbxChsNumber.AutoSize = true;
-            this.cbxChsNumber.Location = new System.Drawing.Point(14, 181);
+            this.cbxChsNumber.Location = new System.Drawing.Point(235, 229);
             this.cbxChsNumber.Margin = new System.Windows.Forms.Padding(4);
             this.cbxChsNumber.Name = "cbxChsNumber";
             this.cbxChsNumber.Size = new System.Drawing.Size(194, 19);
@@ -451,7 +455,7 @@ namespace Studyzy.IMEWLConverter
             this.cbxPrefixEnglish.AutoSize = true;
             this.cbxPrefixEnglish.Checked = true;
             this.cbxPrefixEnglish.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbxPrefixEnglish.Location = new System.Drawing.Point(235, 181);
+            this.cbxPrefixEnglish.Location = new System.Drawing.Point(14, 229);
             this.cbxPrefixEnglish.Margin = new System.Windows.Forms.Padding(4);
             this.cbxPrefixEnglish.Name = "cbxPrefixEnglish";
             this.cbxPrefixEnglish.Size = new System.Drawing.Size(218, 19);
@@ -465,7 +469,7 @@ namespace Studyzy.IMEWLConverter
             this.cbxKeepPunctuation_.AutoSize = true;
             this.cbxKeepPunctuation_.Checked = true;
             this.cbxKeepPunctuation_.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbxKeepPunctuation_.Location = new System.Drawing.Point(14, 135);
+            this.cbxKeepPunctuation_.Location = new System.Drawing.Point(14, 181);
             this.cbxKeepPunctuation_.Margin = new System.Windows.Forms.Padding(4);
             this.cbxKeepPunctuation_.Name = "cbxKeepPunctuation_";
             this.cbxKeepPunctuation_.Size = new System.Drawing.Size(164, 19);
@@ -477,7 +481,7 @@ namespace Studyzy.IMEWLConverter
             // cbxKeepPunctuation
             // 
             this.cbxKeepPunctuation.AutoSize = true;
-            this.cbxKeepPunctuation.Location = new System.Drawing.Point(235, 135);
+            this.cbxKeepPunctuation.Location = new System.Drawing.Point(235, 181);
             this.cbxKeepPunctuation.Margin = new System.Windows.Forms.Padding(4);
             this.cbxKeepPunctuation.Name = "cbxKeepPunctuation";
             this.cbxKeepPunctuation.Size = new System.Drawing.Size(194, 19);
@@ -490,10 +494,32 @@ namespace Studyzy.IMEWLConverter
             // 
             this.groupBox2.Location = new System.Drawing.Point(210, 155);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(200, 234);
+            this.groupBox2.Size = new System.Drawing.Size(200, 269);
             this.groupBox2.TabIndex = 24;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "词条字符替换";
+            // 
+            // cbxKeepSpace_
+            // 
+            this.cbxKeepSpace_.AutoSize = true;
+            this.cbxKeepSpace_.Location = new System.Drawing.Point(14, 135);
+            this.cbxKeepSpace_.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxKeepSpace_.Name = "cbxKeepSpace_";
+            this.cbxKeepSpace_.Size = new System.Drawing.Size(164, 19);
+            this.cbxKeepSpace_.TabIndex = 27;
+            this.cbxKeepSpace_.Text = "词条中的空格不编码";
+            this.cbxKeepSpace_.UseVisualStyleBackColor = true;
+            // 
+            // cbxKeepSpace
+            // 
+            this.cbxKeepSpace.AutoSize = true;
+            this.cbxKeepSpace.Location = new System.Drawing.Point(235, 135);
+            this.cbxKeepSpace.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxKeepSpace.Name = "cbxKeepSpace";
+            this.cbxKeepSpace.Size = new System.Drawing.Size(194, 19);
+            this.cbxKeepSpace.TabIndex = 28;
+            this.cbxKeepSpace.Text = "编码时保留字母后的空格";
+            this.cbxKeepSpace.UseVisualStyleBackColor = true;
             // 
             // FilterConfigForm
             // 
@@ -580,5 +606,7 @@ namespace Studyzy.IMEWLConverter
         private System.Windows.Forms.CheckBox cbxPrefixEnglish;
         private System.Windows.Forms.CheckBox cbxKeepPunctuation_;
         private System.Windows.Forms.CheckBox cbxChsNumber;
+        private System.Windows.Forms.CheckBox cbxKeepSpace_;
+        private System.Windows.Forms.CheckBox cbxKeepSpace;
     }
 }

--- a/src/IME WL Converter Win/Forms/FilterConfigForm.Designer.cs
+++ b/src/IME WL Converter Win/Forms/FilterConfigForm.Designer.cs
@@ -67,18 +67,31 @@ namespace Studyzy.IMEWLConverter
             this.numWordRankPercentage = new System.Windows.Forms.NumericUpDown();
             this.label6 = new System.Windows.Forms.Label();
             this.cbxFilterNoAlphabetCode = new System.Windows.Forms.CheckBox();
+            this.cbxKeepNumber = new System.Windows.Forms.CheckBox();
+            this.cbxKeepEnglish = new System.Windows.Forms.CheckBox();
+            this.cbxFilterFirstCJK = new System.Windows.Forms.CheckBox();
+            this.cbxKeepNumber_ = new System.Windows.Forms.CheckBox();
+            this.cbxKeepEnglish_ = new System.Windows.Forms.CheckBox();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.cbxChsNumber = new System.Windows.Forms.CheckBox();
+            this.cbxPrefixEnglish = new System.Windows.Forms.CheckBox();
+            this.cbxKeepPunctuation_ = new System.Windows.Forms.CheckBox();
+            this.cbxKeepPunctuation = new System.Windows.Forms.CheckBox();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
             ((System.ComponentModel.ISupportInitialize)(this.numWordLengthFrom)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numWordLengthTo)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numWordRankFrom)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numWordRankTo)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numWordRankPercentage)).BeginInit();
+            this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnOK
             // 
-            this.btnOK.Location = new System.Drawing.Point(189, 300);
+            this.btnOK.Location = new System.Drawing.Point(752, 431);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(4);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(75, 23);
+            this.btnOK.Size = new System.Drawing.Size(100, 29);
             this.btnOK.TabIndex = 0;
             this.btnOK.Text = "确定";
             this.btnOK.UseVisualStyleBackColor = true;
@@ -86,14 +99,15 @@ namespace Studyzy.IMEWLConverter
             // 
             // numWordLengthFrom
             // 
-            this.numWordLengthFrom.Location = new System.Drawing.Point(97, 21);
+            this.numWordLengthFrom.Location = new System.Drawing.Point(129, 26);
+            this.numWordLengthFrom.Margin = new System.Windows.Forms.Padding(4);
             this.numWordLengthFrom.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.numWordLengthFrom.Name = "numWordLengthFrom";
-            this.numWordLengthFrom.Size = new System.Drawing.Size(65, 21);
+            this.numWordLengthFrom.Size = new System.Drawing.Size(87, 25);
             this.numWordLengthFrom.TabIndex = 1;
             this.numWordLengthFrom.Value = new decimal(new int[] {
             1,
@@ -104,26 +118,29 @@ namespace Studyzy.IMEWLConverter
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 23);
+            this.label1.Location = new System.Drawing.Point(16, 29);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(83, 12);
+            this.label1.Size = new System.Drawing.Size(105, 15);
             this.label1.TabIndex = 2;
             this.label1.Text = "保留字数： 从";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(12, 59);
+            this.label2.Location = new System.Drawing.Point(16, 74);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(83, 12);
+            this.label2.Size = new System.Drawing.Size(105, 15);
             this.label2.TabIndex = 3;
             this.label2.Text = "保留词频： 从";
             // 
             // numWordLengthTo
             // 
-            this.numWordLengthTo.Location = new System.Drawing.Point(199, 21);
+            this.numWordLengthTo.Location = new System.Drawing.Point(265, 26);
+            this.numWordLengthTo.Margin = new System.Windows.Forms.Padding(4);
             this.numWordLengthTo.Name = "numWordLengthTo";
-            this.numWordLengthTo.Size = new System.Drawing.Size(65, 21);
+            this.numWordLengthTo.Size = new System.Drawing.Size(87, 25);
             this.numWordLengthTo.TabIndex = 1;
             this.numWordLengthTo.Value = new decimal(new int[] {
             100,
@@ -134,22 +151,24 @@ namespace Studyzy.IMEWLConverter
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(168, 23);
+            this.label3.Location = new System.Drawing.Point(224, 29);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(17, 12);
+            this.label3.Size = new System.Drawing.Size(22, 15);
             this.label3.TabIndex = 4;
             this.label3.Text = "到";
             // 
             // numWordRankFrom
             // 
-            this.numWordRankFrom.Location = new System.Drawing.Point(97, 57);
+            this.numWordRankFrom.Location = new System.Drawing.Point(129, 71);
+            this.numWordRankFrom.Margin = new System.Windows.Forms.Padding(4);
             this.numWordRankFrom.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.numWordRankFrom.Name = "numWordRankFrom";
-            this.numWordRankFrom.Size = new System.Drawing.Size(65, 21);
+            this.numWordRankFrom.Size = new System.Drawing.Size(87, 25);
             this.numWordRankFrom.TabIndex = 1;
             this.numWordRankFrom.Value = new decimal(new int[] {
             2,
@@ -159,14 +178,15 @@ namespace Studyzy.IMEWLConverter
             // 
             // numWordRankTo
             // 
-            this.numWordRankTo.Location = new System.Drawing.Point(199, 57);
+            this.numWordRankTo.Location = new System.Drawing.Point(265, 71);
+            this.numWordRankTo.Margin = new System.Windows.Forms.Padding(4);
             this.numWordRankTo.Maximum = new decimal(new int[] {
             999999,
             0,
             0,
             0});
             this.numWordRankTo.Name = "numWordRankTo";
-            this.numWordRankTo.Size = new System.Drawing.Size(65, 21);
+            this.numWordRankTo.Size = new System.Drawing.Size(87, 25);
             this.numWordRankTo.TabIndex = 1;
             this.numWordRankTo.Value = new decimal(new int[] {
             999999,
@@ -177,20 +197,20 @@ namespace Studyzy.IMEWLConverter
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(168, 59);
+            this.label4.Location = new System.Drawing.Point(224, 74);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(17, 12);
+            this.label4.Size = new System.Drawing.Size(22, 15);
             this.label4.TabIndex = 4;
             this.label4.Text = "到";
             // 
             // cbxFilterEnglish
             // 
             this.cbxFilterEnglish.AutoSize = true;
-            this.cbxFilterEnglish.Checked = true;
-            this.cbxFilterEnglish.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbxFilterEnglish.Location = new System.Drawing.Point(14, 124);
+            this.cbxFilterEnglish.Location = new System.Drawing.Point(22, 201);
+            this.cbxFilterEnglish.Margin = new System.Windows.Forms.Padding(4);
             this.cbxFilterEnglish.Name = "cbxFilterEnglish";
-            this.cbxFilterEnglish.Size = new System.Drawing.Size(120, 16);
+            this.cbxFilterEnglish.Size = new System.Drawing.Size(149, 19);
             this.cbxFilterEnglish.TabIndex = 5;
             this.cbxFilterEnglish.Text = "过滤包含英文的词";
             this.cbxFilterEnglish.UseVisualStyleBackColor = true;
@@ -198,11 +218,10 @@ namespace Studyzy.IMEWLConverter
             // cbxFilterSpace
             // 
             this.cbxFilterSpace.AutoSize = true;
-            this.cbxFilterSpace.Checked = true;
-            this.cbxFilterSpace.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbxFilterSpace.Location = new System.Drawing.Point(14, 195);
+            this.cbxFilterSpace.Location = new System.Drawing.Point(22, 290);
+            this.cbxFilterSpace.Margin = new System.Windows.Forms.Padding(4);
             this.cbxFilterSpace.Name = "cbxFilterSpace";
-            this.cbxFilterSpace.Size = new System.Drawing.Size(120, 16);
+            this.cbxFilterSpace.Size = new System.Drawing.Size(149, 19);
             this.cbxFilterSpace.TabIndex = 6;
             this.cbxFilterSpace.Text = "过滤包含空格的词";
             this.cbxFilterSpace.UseVisualStyleBackColor = true;
@@ -210,11 +229,10 @@ namespace Studyzy.IMEWLConverter
             // cbxFilterPunctuation
             // 
             this.cbxFilterPunctuation.AutoSize = true;
-            this.cbxFilterPunctuation.Checked = true;
-            this.cbxFilterPunctuation.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbxFilterPunctuation.Location = new System.Drawing.Point(14, 232);
+            this.cbxFilterPunctuation.Location = new System.Drawing.Point(22, 336);
+            this.cbxFilterPunctuation.Margin = new System.Windows.Forms.Padding(4);
             this.cbxFilterPunctuation.Name = "cbxFilterPunctuation";
-            this.cbxFilterPunctuation.Size = new System.Drawing.Size(120, 16);
+            this.cbxFilterPunctuation.Size = new System.Drawing.Size(149, 19);
             this.cbxFilterPunctuation.TabIndex = 7;
             this.cbxFilterPunctuation.Text = "过滤包含标点的词";
             this.cbxFilterPunctuation.UseVisualStyleBackColor = true;
@@ -222,9 +240,10 @@ namespace Studyzy.IMEWLConverter
             // cbxNoFilter
             // 
             this.cbxNoFilter.AutoSize = true;
-            this.cbxNoFilter.Location = new System.Drawing.Point(12, 307);
+            this.cbxNoFilter.Location = new System.Drawing.Point(22, 155);
+            this.cbxNoFilter.Margin = new System.Windows.Forms.Padding(4);
             this.cbxNoFilter.Name = "cbxNoFilter";
-            this.cbxNoFilter.Size = new System.Drawing.Size(60, 16);
+            this.cbxNoFilter.Size = new System.Drawing.Size(74, 19);
             this.cbxNoFilter.TabIndex = 8;
             this.cbxNoFilter.Text = "不过滤";
             this.cbxNoFilter.UseVisualStyleBackColor = true;
@@ -232,9 +251,10 @@ namespace Studyzy.IMEWLConverter
             // cbxReplacePunctuation
             // 
             this.cbxReplacePunctuation.AutoSize = true;
-            this.cbxReplacePunctuation.Location = new System.Drawing.Point(170, 232);
+            this.cbxReplacePunctuation.Location = new System.Drawing.Point(227, 336);
+            this.cbxReplacePunctuation.Margin = new System.Windows.Forms.Padding(4);
             this.cbxReplacePunctuation.Name = "cbxReplacePunctuation";
-            this.cbxReplacePunctuation.Size = new System.Drawing.Size(96, 16);
+            this.cbxReplacePunctuation.Size = new System.Drawing.Size(119, 19);
             this.cbxReplacePunctuation.TabIndex = 11;
             this.cbxReplacePunctuation.Text = "替换标点部分";
             this.cbxReplacePunctuation.UseVisualStyleBackColor = true;
@@ -242,9 +262,10 @@ namespace Studyzy.IMEWLConverter
             // cbxReplaceSpace
             // 
             this.cbxReplaceSpace.AutoSize = true;
-            this.cbxReplaceSpace.Location = new System.Drawing.Point(170, 195);
+            this.cbxReplaceSpace.Location = new System.Drawing.Point(227, 290);
+            this.cbxReplaceSpace.Margin = new System.Windows.Forms.Padding(4);
             this.cbxReplaceSpace.Name = "cbxReplaceSpace";
-            this.cbxReplaceSpace.Size = new System.Drawing.Size(96, 16);
+            this.cbxReplaceSpace.Size = new System.Drawing.Size(119, 19);
             this.cbxReplaceSpace.TabIndex = 10;
             this.cbxReplaceSpace.Text = "替换空格部分";
             this.cbxReplaceSpace.UseVisualStyleBackColor = true;
@@ -252,9 +273,10 @@ namespace Studyzy.IMEWLConverter
             // cbxReplaceEnglish
             // 
             this.cbxReplaceEnglish.AutoSize = true;
-            this.cbxReplaceEnglish.Location = new System.Drawing.Point(170, 124);
+            this.cbxReplaceEnglish.Location = new System.Drawing.Point(227, 201);
+            this.cbxReplaceEnglish.Margin = new System.Windows.Forms.Padding(4);
             this.cbxReplaceEnglish.Name = "cbxReplaceEnglish";
-            this.cbxReplaceEnglish.Size = new System.Drawing.Size(96, 16);
+            this.cbxReplaceEnglish.Size = new System.Drawing.Size(119, 19);
             this.cbxReplaceEnglish.TabIndex = 9;
             this.cbxReplaceEnglish.Text = "替换英文部分";
             this.cbxReplaceEnglish.UseVisualStyleBackColor = true;
@@ -262,9 +284,10 @@ namespace Studyzy.IMEWLConverter
             // cbxReplaceNumber
             // 
             this.cbxReplaceNumber.AutoSize = true;
-            this.cbxReplaceNumber.Location = new System.Drawing.Point(170, 160);
+            this.cbxReplaceNumber.Location = new System.Drawing.Point(227, 246);
+            this.cbxReplaceNumber.Margin = new System.Windows.Forms.Padding(4);
             this.cbxReplaceNumber.Name = "cbxReplaceNumber";
-            this.cbxReplaceNumber.Size = new System.Drawing.Size(96, 16);
+            this.cbxReplaceNumber.Size = new System.Drawing.Size(119, 19);
             this.cbxReplaceNumber.TabIndex = 13;
             this.cbxReplaceNumber.Text = "替换数字部分";
             this.cbxReplaceNumber.UseVisualStyleBackColor = true;
@@ -272,11 +295,10 @@ namespace Studyzy.IMEWLConverter
             // cbxFilterNumber
             // 
             this.cbxFilterNumber.AutoSize = true;
-            this.cbxFilterNumber.Checked = true;
-            this.cbxFilterNumber.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbxFilterNumber.Location = new System.Drawing.Point(14, 160);
+            this.cbxFilterNumber.Location = new System.Drawing.Point(22, 246);
+            this.cbxFilterNumber.Margin = new System.Windows.Forms.Padding(4);
             this.cbxFilterNumber.Name = "cbxFilterNumber";
-            this.cbxFilterNumber.Size = new System.Drawing.Size(120, 16);
+            this.cbxFilterNumber.Size = new System.Drawing.Size(149, 19);
             this.cbxFilterNumber.TabIndex = 12;
             this.cbxFilterNumber.Text = "过滤包含数字的词";
             this.cbxFilterNumber.UseVisualStyleBackColor = true;
@@ -284,22 +306,24 @@ namespace Studyzy.IMEWLConverter
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(12, 91);
+            this.label5.Location = new System.Drawing.Point(16, 114);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(77, 12);
+            this.label5.Size = new System.Drawing.Size(97, 15);
             this.label5.TabIndex = 14;
             this.label5.Text = "保留高词频：";
             // 
             // numWordRankPercentage
             // 
-            this.numWordRankPercentage.Location = new System.Drawing.Point(96, 87);
+            this.numWordRankPercentage.Location = new System.Drawing.Point(128, 109);
+            this.numWordRankPercentage.Margin = new System.Windows.Forms.Padding(4);
             this.numWordRankPercentage.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.numWordRankPercentage.Name = "numWordRankPercentage";
-            this.numWordRankPercentage.Size = new System.Drawing.Size(65, 21);
+            this.numWordRankPercentage.Size = new System.Drawing.Size(87, 25);
             this.numWordRankPercentage.TabIndex = 15;
             this.numWordRankPercentage.Value = new decimal(new int[] {
             100,
@@ -310,27 +334,174 @@ namespace Studyzy.IMEWLConverter
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(167, 89);
+            this.label6.Location = new System.Drawing.Point(223, 111);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(11, 12);
+            this.label6.Size = new System.Drawing.Size(15, 15);
             this.label6.TabIndex = 16;
             this.label6.Text = "%";
             // 
             // cbxFilterNoAlphabetCode
             // 
             this.cbxFilterNoAlphabetCode.AutoSize = true;
-            this.cbxFilterNoAlphabetCode.Location = new System.Drawing.Point(12, 270);
+            this.cbxFilterNoAlphabetCode.Location = new System.Drawing.Point(22, 384);
+            this.cbxFilterNoAlphabetCode.Margin = new System.Windows.Forms.Padding(4);
             this.cbxFilterNoAlphabetCode.Name = "cbxFilterNoAlphabetCode";
-            this.cbxFilterNoAlphabetCode.Size = new System.Drawing.Size(132, 16);
+            this.cbxFilterNoAlphabetCode.Size = new System.Drawing.Size(164, 19);
             this.cbxFilterNoAlphabetCode.TabIndex = 17;
             this.cbxFilterNoAlphabetCode.Text = "过滤非字母编码的词";
             this.cbxFilterNoAlphabetCode.UseVisualStyleBackColor = true;
             // 
+            // cbxKeepNumber
+            // 
+            this.cbxKeepNumber.AutoSize = true;
+            this.cbxKeepNumber.Location = new System.Drawing.Point(235, 91);
+            this.cbxKeepNumber.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxKeepNumber.Name = "cbxKeepNumber";
+            this.cbxKeepNumber.Size = new System.Drawing.Size(194, 19);
+            this.cbxKeepNumber.TabIndex = 19;
+            this.cbxKeepNumber.Text = "词条中的数字直接当编码";
+            this.cbxKeepNumber.UseVisualStyleBackColor = true;
+            this.cbxKeepNumber.CheckedChanged += new System.EventHandler(this.cbxKeepNumber_CheckedChanged);
+            // 
+            // cbxKeepEnglish
+            // 
+            this.cbxKeepEnglish.AutoSize = true;
+            this.cbxKeepEnglish.Checked = true;
+            this.cbxKeepEnglish.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbxKeepEnglish.Location = new System.Drawing.Point(235, 45);
+            this.cbxKeepEnglish.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxKeepEnglish.Name = "cbxKeepEnglish";
+            this.cbxKeepEnglish.Size = new System.Drawing.Size(194, 19);
+            this.cbxKeepEnglish.TabIndex = 18;
+            this.cbxKeepEnglish.Text = "词条中的字母直接当编码";
+            this.cbxKeepEnglish.UseVisualStyleBackColor = true;
+            this.cbxKeepEnglish.CheckedChanged += new System.EventHandler(this.cbxKeepEnglish_CheckedChanged);
+            // 
+            // cbxFilterFirstCJK
+            // 
+            this.cbxFilterFirstCJK.AutoSize = true;
+            this.cbxFilterFirstCJK.Checked = true;
+            this.cbxFilterFirstCJK.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbxFilterFirstCJK.Location = new System.Drawing.Point(22, 431);
+            this.cbxFilterFirstCJK.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxFilterFirstCJK.Name = "cbxFilterFirstCJK";
+            this.cbxFilterFirstCJK.Size = new System.Drawing.Size(224, 19);
+            this.cbxFilterFirstCJK.TabIndex = 20;
+            this.cbxFilterFirstCJK.Text = "首字位于中日韩统一表义符区";
+            this.cbxFilterFirstCJK.UseVisualStyleBackColor = true;
+            // 
+            // cbxKeepNumber_
+            // 
+            this.cbxKeepNumber_.AutoSize = true;
+            this.cbxKeepNumber_.Checked = true;
+            this.cbxKeepNumber_.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbxKeepNumber_.Location = new System.Drawing.Point(14, 91);
+            this.cbxKeepNumber_.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxKeepNumber_.Name = "cbxKeepNumber_";
+            this.cbxKeepNumber_.Size = new System.Drawing.Size(164, 19);
+            this.cbxKeepNumber_.TabIndex = 22;
+            this.cbxKeepNumber_.Text = "词条中的数字不编码";
+            this.cbxKeepNumber_.UseVisualStyleBackColor = true;
+            this.cbxKeepNumber_.CheckedChanged += new System.EventHandler(this.cbxKeepNumber__CheckedChanged);
+            // 
+            // cbxKeepEnglish_
+            // 
+            this.cbxKeepEnglish_.AutoSize = true;
+            this.cbxKeepEnglish_.Location = new System.Drawing.Point(14, 45);
+            this.cbxKeepEnglish_.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxKeepEnglish_.Name = "cbxKeepEnglish_";
+            this.cbxKeepEnglish_.Size = new System.Drawing.Size(164, 19);
+            this.cbxKeepEnglish_.TabIndex = 21;
+            this.cbxKeepEnglish_.Text = "词条中的字母不编码";
+            this.cbxKeepEnglish_.UseVisualStyleBackColor = true;
+            this.cbxKeepEnglish_.CheckedChanged += new System.EventHandler(this.cbxKeepEnglish__CheckedChanged);
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.cbxChsNumber);
+            this.groupBox1.Controls.Add(this.cbxPrefixEnglish);
+            this.groupBox1.Controls.Add(this.cbxKeepPunctuation_);
+            this.groupBox1.Controls.Add(this.cbxKeepPunctuation);
+            this.groupBox1.Controls.Add(this.cbxKeepNumber_);
+            this.groupBox1.Controls.Add(this.cbxKeepEnglish_);
+            this.groupBox1.Controls.Add(this.cbxKeepNumber);
+            this.groupBox1.Controls.Add(this.cbxKeepEnglish);
+            this.groupBox1.Location = new System.Drawing.Point(423, 155);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(471, 234);
+            this.groupBox1.TabIndex = 23;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "词条分段处理";
+            // 
+            // cbxChsNumber
+            // 
+            this.cbxChsNumber.AutoSize = true;
+            this.cbxChsNumber.Location = new System.Drawing.Point(14, 181);
+            this.cbxChsNumber.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxChsNumber.Name = "cbxChsNumber";
+            this.cbxChsNumber.Size = new System.Drawing.Size(194, 19);
+            this.cbxChsNumber.TabIndex = 26;
+            this.cbxChsNumber.Text = "数字先转汉字再进行编码";
+            this.cbxChsNumber.UseVisualStyleBackColor = true;
+            this.cbxChsNumber.CheckedChanged += new System.EventHandler(this.cbxChsNumber_CheckedChanged);
+            // 
+            // cbxPrefixEnglish
+            // 
+            this.cbxPrefixEnglish.AutoSize = true;
+            this.cbxPrefixEnglish.Checked = true;
+            this.cbxPrefixEnglish.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbxPrefixEnglish.Location = new System.Drawing.Point(235, 181);
+            this.cbxPrefixEnglish.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxPrefixEnglish.Name = "cbxPrefixEnglish";
+            this.cbxPrefixEnglish.Size = new System.Drawing.Size(218, 19);
+            this.cbxPrefixEnglish.TabIndex = 25;
+            this.cbxPrefixEnglish.Text = "中英文的编码中间用\"_\"分隔";
+            this.cbxPrefixEnglish.UseVisualStyleBackColor = true;
+            this.cbxPrefixEnglish.CheckedChanged += new System.EventHandler(this.cbxPrefixEnglish_CheckedChanged);
+            // 
+            // cbxKeepPunctuation_
+            // 
+            this.cbxKeepPunctuation_.AutoSize = true;
+            this.cbxKeepPunctuation_.Checked = true;
+            this.cbxKeepPunctuation_.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbxKeepPunctuation_.Location = new System.Drawing.Point(14, 135);
+            this.cbxKeepPunctuation_.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxKeepPunctuation_.Name = "cbxKeepPunctuation_";
+            this.cbxKeepPunctuation_.Size = new System.Drawing.Size(164, 19);
+            this.cbxKeepPunctuation_.TabIndex = 24;
+            this.cbxKeepPunctuation_.Text = "词条中的标点不编码";
+            this.cbxKeepPunctuation_.UseVisualStyleBackColor = true;
+            this.cbxKeepPunctuation_.CheckedChanged += new System.EventHandler(this.cbxKeepPunctuation__CheckedChanged);
+            // 
+            // cbxKeepPunctuation
+            // 
+            this.cbxKeepPunctuation.AutoSize = true;
+            this.cbxKeepPunctuation.Location = new System.Drawing.Point(235, 135);
+            this.cbxKeepPunctuation.Margin = new System.Windows.Forms.Padding(4);
+            this.cbxKeepPunctuation.Name = "cbxKeepPunctuation";
+            this.cbxKeepPunctuation.Size = new System.Drawing.Size(194, 19);
+            this.cbxKeepPunctuation.TabIndex = 23;
+            this.cbxKeepPunctuation.Text = "词条中的标点直接当编码";
+            this.cbxKeepPunctuation.UseVisualStyleBackColor = true;
+            this.cbxKeepPunctuation.CheckedChanged += new System.EventHandler(this.cbxKeepPunctuator_CheckedChanged);
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Location = new System.Drawing.Point(210, 155);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(200, 234);
+            this.groupBox2.TabIndex = 24;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "词条字符替换";
+            // 
             // FilterConfigForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(285, 335);
+            this.ClientSize = new System.Drawing.Size(909, 485);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.cbxFilterFirstCJK);
             this.Controls.Add(this.cbxFilterNoAlphabetCode);
             this.Controls.Add(this.label6);
             this.Controls.Add(this.numWordRankPercentage);
@@ -353,7 +524,9 @@ namespace Studyzy.IMEWLConverter
             this.Controls.Add(this.numWordLengthTo);
             this.Controls.Add(this.numWordLengthFrom);
             this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.groupBox2);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FilterConfigForm";
@@ -365,6 +538,8 @@ namespace Studyzy.IMEWLConverter
             ((System.ComponentModel.ISupportInitialize)(this.numWordRankFrom)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numWordRankTo)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numWordRankPercentage)).EndInit();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -394,5 +569,16 @@ namespace Studyzy.IMEWLConverter
         private System.Windows.Forms.NumericUpDown numWordRankPercentage;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.CheckBox cbxFilterNoAlphabetCode;
+        private System.Windows.Forms.CheckBox cbxKeepNumber;
+        private System.Windows.Forms.CheckBox cbxKeepEnglish;
+        private System.Windows.Forms.CheckBox cbxFilterFirstCJK;
+        private System.Windows.Forms.CheckBox cbxKeepNumber_;
+        private System.Windows.Forms.CheckBox cbxKeepEnglish_;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.CheckBox cbxKeepPunctuation;
+        private System.Windows.Forms.CheckBox cbxPrefixEnglish;
+        private System.Windows.Forms.CheckBox cbxKeepPunctuation_;
+        private System.Windows.Forms.CheckBox cbxChsNumber;
     }
 }

--- a/src/IME WL Converter Win/Forms/FilterConfigForm.cs
+++ b/src/IME WL Converter Win/Forms/FilterConfigForm.cs
@@ -60,7 +60,7 @@ namespace Studyzy.IMEWLConverter
 
             filterConfig.KeepEnglish = cbxKeepEnglish.Checked;
             filterConfig.KeepNumber = cbxKeepNumber.Checked;
-            filterConfig.KeepPunctuation = cbxFilterPunctuation.Checked;
+            filterConfig.KeepPunctuation = cbxKeepPunctuation.Checked;
 
             filterConfig.KeepEnglish_ = cbxKeepEnglish_.Checked;
             filterConfig.KeepNumber_ = cbxKeepNumber_.Checked;
@@ -100,7 +100,7 @@ namespace Studyzy.IMEWLConverter
             cbxKeepEnglish_.Checked = filterConfig.KeepEnglish_;
             cbxKeepNumber_.Checked = filterConfig.KeepNumber_;
             cbxFilterFirstCJK.Checked = filterConfig.IgnoreFirstCJK;
-            cbxFilterPunctuation.Checked = filterConfig.KeepPunctuation;
+            cbxKeepPunctuation.Checked = filterConfig.KeepPunctuation;
             cbxKeepPunctuation_.Checked = filterConfig.KeepPunctuation_;
             cbxChsNumber.Checked = filterConfig.ChsNumber;
             cbxPrefixEnglish.Checked = filterConfig.PrefixEnglish;

--- a/src/IME WL Converter Win/Forms/FilterConfigForm.cs
+++ b/src/IME WL Converter Win/Forms/FilterConfigForm.cs
@@ -57,6 +57,21 @@ namespace Studyzy.IMEWLConverter
             filterConfig.ReplaceEnglish = cbxReplaceEnglish.Checked;
             filterConfig.ReplaceSpace = cbxReplaceSpace.Checked;
             filterConfig.ReplacePunctuation = cbxReplacePunctuation.Checked;
+
+            filterConfig.KeepEnglish = cbxKeepEnglish.Checked;
+            filterConfig.KeepNumber = cbxKeepNumber.Checked;
+            filterConfig.KeepPunctuation = cbxFilterPunctuation.Checked;
+
+            filterConfig.KeepEnglish_ = cbxKeepEnglish_.Checked;
+            filterConfig.KeepNumber_ = cbxKeepNumber_.Checked;
+
+            filterConfig.KeepPunctuation_ = cbxKeepPunctuation_.Checked;
+
+            filterConfig.ChsNumber = cbxChsNumber.Checked;
+            filterConfig.PrefixEnglish = cbxPrefixEnglish.Checked;
+
+            filterConfig.IgnoreFirstCJK = cbxFilterFirstCJK.Checked;
+
             DialogResult = DialogResult.OK;
         }
 
@@ -77,6 +92,86 @@ namespace Studyzy.IMEWLConverter
             cbxReplacePunctuation.Checked = filterConfig.ReplacePunctuation;
             cbxReplaceSpace.Checked = filterConfig.ReplaceSpace;
             cbxFilterNoAlphabetCode.Checked = filterConfig.IgnoreNoAlphabetCode;
+            cbxKeepEnglish.Checked = filterConfig.KeepEnglish;
+            cbxKeepNumber.Checked = filterConfig.KeepNumber;
+            cbxKeepEnglish_.Checked = filterConfig.KeepEnglish_;
+            cbxKeepNumber_.Checked = filterConfig.KeepNumber_;
+            cbxFilterFirstCJK.Checked = filterConfig.IgnoreFirstCJK;
+            cbxFilterPunctuation.Checked = filterConfig.KeepPunctuation;
+            cbxKeepPunctuation_.Checked = filterConfig.KeepPunctuation_;
+            cbxChsNumber.Checked = filterConfig.ChsNumber;
+            cbxPrefixEnglish.Checked = filterConfig.PrefixEnglish;
+        }
+
+        private void cbxKeepNumber_CheckedChanged(object sender, EventArgs e)
+        {
+            if (cbxKeepNumber.Checked)
+            {
+                cbxKeepNumber_.Checked = false;
+                cbxChsNumber.Checked = false;
+            }
+        }
+
+        private void cbxKeepNumber__CheckedChanged(object sender, EventArgs e)
+        {
+            if (cbxKeepNumber_.Checked)
+            {
+            cbxKeepNumber.Checked = false;
+            cbxChsNumber.Checked = false;
+            }
+
+        }
+
+        private void cbxKeepEnglish_CheckedChanged(object sender, EventArgs e)
+        {
+            if (cbxKeepEnglish.Checked)
+            {
+                cbxKeepEnglish_.Checked = false;
+            }
+
+        }
+
+        private void cbxKeepEnglish__CheckedChanged(object sender, EventArgs e)
+        {
+            if (cbxKeepEnglish_.Checked) {
+                cbxKeepEnglish.Checked = false;
+                cbxPrefixEnglish.Checked = false;
+            }
+
+        }
+
+        private void cbxPrefixEnglish_CheckedChanged(object sender, EventArgs e)
+        {
+            if (cbxPrefixEnglish.Checked)
+            {
+                cbxKeepEnglish_.Checked = false;
+                cbxKeepEnglish.Checked = true;
+            }
+        }
+
+        private void cbxKeepPunctuator_CheckedChanged(object sender, EventArgs e)
+        {
+            if (cbxKeepPunctuation.Checked)
+            {
+                cbxKeepPunctuation_.Checked = false;
+            }
+        }
+
+        private void cbxKeepPunctuation__CheckedChanged(object sender, EventArgs e)
+        {
+            if (cbxKeepPunctuation_.Checked)
+            {
+                cbxKeepPunctuation.Checked = false;
+            }
+        }
+
+        private void cbxChsNumber_CheckedChanged(object sender, EventArgs e)
+        {
+            if (cbxChsNumber.Checked)
+            {
+                cbxKeepNumber.Checked = false;
+                cbxKeepNumber_.Checked = false;
+            }
         }
     }
 }

--- a/src/IME WL Converter Win/Forms/FilterConfigForm.cs
+++ b/src/IME WL Converter Win/Forms/FilterConfigForm.cs
@@ -72,6 +72,9 @@ namespace Studyzy.IMEWLConverter
 
             filterConfig.IgnoreFirstCJK = cbxFilterFirstCJK.Checked;
 
+            filterConfig.KeepSpace_ = cbxKeepSpace_.Checked;
+            filterConfig.KeepSpace = cbxKeepSpace.Checked;
+
             DialogResult = DialogResult.OK;
         }
 
@@ -101,6 +104,8 @@ namespace Studyzy.IMEWLConverter
             cbxKeepPunctuation_.Checked = filterConfig.KeepPunctuation_;
             cbxChsNumber.Checked = filterConfig.ChsNumber;
             cbxPrefixEnglish.Checked = filterConfig.PrefixEnglish;
+            cbxKeepSpace_.Checked = filterConfig.KeepSpace_;
+            cbxKeepSpace.Checked = filterConfig.KeepSpace;
         }
 
         private void cbxKeepNumber_CheckedChanged(object sender, EventArgs e)

--- a/src/IME WL Converter Win/Forms/MainForm.Designer.cs
+++ b/src/IME WL Converter Win/Forms/MainForm.Designer.cs
@@ -79,6 +79,7 @@ namespace Studyzy.IMEWLConverter
             this.timer1 = new System.Windows.Forms.Timer(this.components);
             this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
+            this.toolStripMenuItemShowLess = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -86,7 +87,7 @@ namespace Studyzy.IMEWLConverter
             // btnConvert
             // 
             this.btnConvert.Location = new System.Drawing.Point(620, 34);
-            this.btnConvert.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btnConvert.Margin = new System.Windows.Forms.Padding(4);
             this.btnConvert.Name = "btnConvert";
             this.btnConvert.Size = new System.Drawing.Size(100, 64);
             this.btnConvert.TabIndex = 0;
@@ -98,7 +99,7 @@ namespace Studyzy.IMEWLConverter
             // 
             this.richTextBox1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(134)));
             this.richTextBox1.Location = new System.Drawing.Point(16, 109);
-            this.richTextBox1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.richTextBox1.Margin = new System.Windows.Forms.Padding(4);
             this.richTextBox1.Name = "richTextBox1";
             this.richTextBox1.Size = new System.Drawing.Size(703, 385);
             this.richTextBox1.TabIndex = 1;
@@ -107,7 +108,7 @@ namespace Studyzy.IMEWLConverter
             // txbWLPath
             // 
             this.txbWLPath.Location = new System.Drawing.Point(16, 34);
-            this.txbWLPath.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txbWLPath.Margin = new System.Windows.Forms.Padding(4);
             this.txbWLPath.Name = "txbWLPath";
             this.txbWLPath.Size = new System.Drawing.Size(527, 25);
             this.txbWLPath.TabIndex = 2;
@@ -124,7 +125,7 @@ namespace Studyzy.IMEWLConverter
             // btnOpenFileDialog
             // 
             this.btnOpenFileDialog.Location = new System.Drawing.Point(552, 32);
-            this.btnOpenFileDialog.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btnOpenFileDialog.Margin = new System.Windows.Forms.Padding(4);
             this.btnOpenFileDialog.Name = "btnOpenFileDialog";
             this.btnOpenFileDialog.Size = new System.Drawing.Size(44, 29);
             this.btnOpenFileDialog.TabIndex = 3;
@@ -138,7 +139,7 @@ namespace Studyzy.IMEWLConverter
             this.cbxFrom.DropDownWidth = 150;
             this.cbxFrom.FormattingEnabled = true;
             this.cbxFrom.Location = new System.Drawing.Point(16, 72);
-            this.cbxFrom.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.cbxFrom.Margin = new System.Windows.Forms.Padding(4);
             this.cbxFrom.Name = "cbxFrom";
             this.cbxFrom.Size = new System.Drawing.Size(260, 23);
             this.cbxFrom.TabIndex = 4;
@@ -149,7 +150,7 @@ namespace Studyzy.IMEWLConverter
             this.cbxTo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbxTo.FormattingEnabled = true;
             this.cbxTo.Location = new System.Drawing.Point(335, 72);
-            this.cbxTo.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.cbxTo.Margin = new System.Windows.Forms.Padding(4);
             this.cbxTo.Name = "cbxTo";
             this.cbxTo.Size = new System.Drawing.Size(260, 23);
             this.cbxTo.TabIndex = 4;
@@ -173,7 +174,6 @@ namespace Studyzy.IMEWLConverter
             this.关于ToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Padding = new System.Windows.Forms.Padding(8, 2, 0, 2);
             this.menuStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional;
             this.menuStrip1.Size = new System.Drawing.Size(732, 30);
             this.menuStrip1.TabIndex = 7;
@@ -185,38 +185,39 @@ namespace Studyzy.IMEWLConverter
             this.toolStripMenuItemFilterConfig,
             this.ToolStripMenuItemRankGenerate,
             this.toolStripSeparator2,
+            this.toolStripMenuItemShowLess,
             this.toolStripMenuItemExportDirectly,
             this.toolStripMenuItemStreamExport,
             this.toolStripMenuItemMergeToOneFile,
             this.ToolStripMenuItemChineseTransConfig});
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(83, 26);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(84, 26);
             this.toolStripMenuItem1.Text = "高级设置";
             // 
             // toolStripMenuItemFilterConfig
             // 
             this.toolStripMenuItemFilterConfig.Name = "toolStripMenuItemFilterConfig";
-            this.toolStripMenuItemFilterConfig.Size = new System.Drawing.Size(242, 26);
+            this.toolStripMenuItemFilterConfig.Size = new System.Drawing.Size(277, 26);
             this.toolStripMenuItemFilterConfig.Text = "词条过滤设置";
             this.toolStripMenuItemFilterConfig.Click += new System.EventHandler(this.toolStripMenuItemFilterConfig_Click);
             // 
             // ToolStripMenuItemRankGenerate
             // 
             this.ToolStripMenuItemRankGenerate.Name = "ToolStripMenuItemRankGenerate";
-            this.ToolStripMenuItemRankGenerate.Size = new System.Drawing.Size(242, 26);
+            this.ToolStripMenuItemRankGenerate.Size = new System.Drawing.Size(277, 26);
             this.ToolStripMenuItemRankGenerate.Text = "词频生成设置";
             this.ToolStripMenuItemRankGenerate.Click += new System.EventHandler(this.ToolStripMenuItemRankGenerate_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(239, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(274, 6);
             // 
             // toolStripMenuItemExportDirectly
             // 
             this.toolStripMenuItemExportDirectly.CheckOnClick = true;
             this.toolStripMenuItemExportDirectly.Name = "toolStripMenuItemExportDirectly";
-            this.toolStripMenuItemExportDirectly.Size = new System.Drawing.Size(242, 26);
+            this.toolStripMenuItemExportDirectly.Size = new System.Drawing.Size(277, 26);
             this.toolStripMenuItemExportDirectly.Text = "不显示结果，直接导出";
             this.toolStripMenuItemExportDirectly.Click += new System.EventHandler(this.toolStripMenuItemExportDirectly_Click);
             // 
@@ -224,7 +225,7 @@ namespace Studyzy.IMEWLConverter
             // 
             this.toolStripMenuItemStreamExport.CheckOnClick = true;
             this.toolStripMenuItemStreamExport.Name = "toolStripMenuItemStreamExport";
-            this.toolStripMenuItemStreamExport.Size = new System.Drawing.Size(242, 26);
+            this.toolStripMenuItemStreamExport.Size = new System.Drawing.Size(277, 26);
             this.toolStripMenuItemStreamExport.Text = "一边读取，一边导出";
             this.toolStripMenuItemStreamExport.ToolTipText = "目前只有文本格式的词库才能支持该功能";
             this.toolStripMenuItemStreamExport.Click += new System.EventHandler(this.toolStripMenuItemStreamExport_Click);
@@ -235,14 +236,14 @@ namespace Studyzy.IMEWLConverter
             this.toolStripMenuItemMergeToOneFile.CheckOnClick = true;
             this.toolStripMenuItemMergeToOneFile.CheckState = System.Windows.Forms.CheckState.Checked;
             this.toolStripMenuItemMergeToOneFile.Name = "toolStripMenuItemMergeToOneFile";
-            this.toolStripMenuItemMergeToOneFile.Size = new System.Drawing.Size(242, 26);
+            this.toolStripMenuItemMergeToOneFile.Size = new System.Drawing.Size(277, 26);
             this.toolStripMenuItemMergeToOneFile.Text = "合并多词库到一个文件";
             this.toolStripMenuItemMergeToOneFile.Click += new System.EventHandler(this.toolStripMenuItemMergeToOneFile_Click);
             // 
             // ToolStripMenuItemChineseTransConfig
             // 
             this.ToolStripMenuItemChineseTransConfig.Name = "ToolStripMenuItemChineseTransConfig";
-            this.ToolStripMenuItemChineseTransConfig.Size = new System.Drawing.Size(242, 26);
+            this.ToolStripMenuItemChineseTransConfig.Size = new System.Drawing.Size(277, 26);
             this.ToolStripMenuItemChineseTransConfig.Text = "简繁体转换设置";
             this.ToolStripMenuItemChineseTransConfig.Click += new System.EventHandler(this.ToolStripMenuItemChineseTransConfig_Click);
             // 
@@ -257,54 +258,54 @@ namespace Studyzy.IMEWLConverter
             this.ToolStripMenuItemSplitFile,
             this.ToolStripMenuItemMergeWL});
             this.关于ToolStripMenuItem.Name = "关于ToolStripMenuItem";
-            this.关于ToolStripMenuItem.Size = new System.Drawing.Size(53, 26);
+            this.关于ToolStripMenuItem.Size = new System.Drawing.Size(54, 26);
             this.关于ToolStripMenuItem.Text = "帮助";
             // 
             // ToolStripMenuItemDonate
             // 
             this.ToolStripMenuItemDonate.Image = ((System.Drawing.Image)(resources.GetObject("ToolStripMenuItemDonate.Image")));
             this.ToolStripMenuItemDonate.Name = "ToolStripMenuItemDonate";
-            this.ToolStripMenuItemDonate.Size = new System.Drawing.Size(182, 26);
+            this.ToolStripMenuItemDonate.Size = new System.Drawing.Size(184, 26);
             this.ToolStripMenuItemDonate.Text = "捐贈";
             this.ToolStripMenuItemDonate.Click += new System.EventHandler(this.ToolStripMenuItemDonate_Click);
             // 
             // ToolStripMenuItemHelp
             // 
             this.ToolStripMenuItemHelp.Name = "ToolStripMenuItemHelp";
-            this.ToolStripMenuItemHelp.Size = new System.Drawing.Size(182, 26);
+            this.ToolStripMenuItemHelp.Size = new System.Drawing.Size(184, 26);
             this.ToolStripMenuItemHelp.Text = "帮助";
             this.ToolStripMenuItemHelp.Click += new System.EventHandler(this.ToolStripMenuItemHelp_Click);
             // 
             // ToolStripMenuItemAbout
             // 
             this.ToolStripMenuItemAbout.Name = "ToolStripMenuItemAbout";
-            this.ToolStripMenuItemAbout.Size = new System.Drawing.Size(182, 26);
+            this.ToolStripMenuItemAbout.Size = new System.Drawing.Size(184, 26);
             this.ToolStripMenuItemAbout.Text = "关于";
             this.ToolStripMenuItemAbout.Click += new System.EventHandler(this.btnAbout_Click);
             // 
             // ToolStripMenuItemAccessWebSite
             // 
             this.ToolStripMenuItemAccessWebSite.Name = "ToolStripMenuItemAccessWebSite";
-            this.ToolStripMenuItemAccessWebSite.Size = new System.Drawing.Size(182, 26);
+            this.ToolStripMenuItemAccessWebSite.Size = new System.Drawing.Size(184, 26);
             this.ToolStripMenuItemAccessWebSite.Text = "查看最新版本";
             this.ToolStripMenuItemAccessWebSite.Click += new System.EventHandler(this.ToolStripMenuItemAccessWebSite_Click);
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(179, 6);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(181, 6);
             // 
             // ToolStripMenuItemSplitFile
             // 
             this.ToolStripMenuItemSplitFile.Name = "ToolStripMenuItemSplitFile";
-            this.ToolStripMenuItemSplitFile.Size = new System.Drawing.Size(182, 26);
+            this.ToolStripMenuItemSplitFile.Size = new System.Drawing.Size(184, 26);
             this.ToolStripMenuItemSplitFile.Text = "文件分割";
             this.ToolStripMenuItemSplitFile.Click += new System.EventHandler(this.ToolStripMenuItemSplitFile_Click);
             // 
             // ToolStripMenuItemMergeWL
             // 
             this.ToolStripMenuItemMergeWL.Name = "ToolStripMenuItemMergeWL";
-            this.ToolStripMenuItemMergeWL.Size = new System.Drawing.Size(182, 26);
+            this.ToolStripMenuItemMergeWL.Size = new System.Drawing.Size(184, 26);
             this.ToolStripMenuItemMergeWL.Text = "词库合并";
             this.ToolStripMenuItemMergeWL.Click += new System.EventHandler(this.ToolStripMenuItemMergeWL_Click);
             // 
@@ -314,22 +315,22 @@ namespace Studyzy.IMEWLConverter
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripProgressBar1,
             this.toolStripStatusLabel1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 502);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 500);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 19, 0);
-            this.statusStrip1.Size = new System.Drawing.Size(732, 26);
+            this.statusStrip1.Size = new System.Drawing.Size(732, 28);
             this.statusStrip1.TabIndex = 9;
             this.statusStrip1.Text = "statusStrip1";
             // 
             // toolStripProgressBar1
             // 
             this.toolStripProgressBar1.Name = "toolStripProgressBar1";
-            this.toolStripProgressBar1.Size = new System.Drawing.Size(133, 18);
+            this.toolStripProgressBar1.Size = new System.Drawing.Size(133, 20);
             // 
             // toolStripStatusLabel1
             // 
             this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
-            this.toolStripStatusLabel1.Size = new System.Drawing.Size(189, 20);
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(190, 22);
             this.toolStripStatusLabel1.Text = "欢迎使用深蓝词库转换工具";
             // 
             // timer1
@@ -341,6 +342,15 @@ namespace Studyzy.IMEWLConverter
             // 
             this.backgroundWorker1.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundWorker1_DoWork);
             this.backgroundWorker1.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.backgroundWorker1_RunWorkerCompleted);
+            // 
+            // toolStripMenuItemShowLess
+            // 
+            this.toolStripMenuItemShowLess.Checked = true;
+            this.toolStripMenuItemShowLess.CheckOnClick = true;
+            this.toolStripMenuItemShowLess.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.toolStripMenuItemShowLess.Name = "toolStripMenuItemShowLess";
+            this.toolStripMenuItemShowLess.Size = new System.Drawing.Size(277, 26);
+            this.toolStripMenuItemShowLess.Text = "结果只显示首、末10万字符";
             // 
             // MainForm
             // 
@@ -359,7 +369,7 @@ namespace Studyzy.IMEWLConverter
             this.Controls.Add(this.menuStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.Name = "MainForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
@@ -410,6 +420,7 @@ namespace Studyzy.IMEWLConverter
         private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemMergeWL;
         private System.Windows.Forms.FolderBrowserDialog folderBrowserDialog1;
         private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemRankGenerate;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemShowLess;
     }
 }
 

--- a/src/IME WL Converter Win/Forms/MainForm.cs
+++ b/src/IME WL Converter Win/Forms/MainForm.cs
@@ -250,6 +250,7 @@ namespace Studyzy.IMEWLConverter
                 mainBody.SortDesc = this.sortDesc;
                 mainBody.BatchFilters = GetBatchFilters();
                 mainBody.ReplaceFilters = GetReplaceFilters();
+                mainBody.FilterConfig = filterConfig;
                 mainBody.Import.ImportLineErrorNotice += WriteErrorMessage;
                 mainBody.Export.ExportErrorNotice += WriteErrorMessage;
                 mainBody.ProcessNotice += RichTextBoxShow;
@@ -304,6 +305,7 @@ namespace Studyzy.IMEWLConverter
             return filters;
         }
 
+
         private IList<ISingleFilter> GetFilters()
         {
             var filters = new List<ISingleFilter>();
@@ -314,6 +316,10 @@ namespace Studyzy.IMEWLConverter
             if (filterConfig.IgnoreEnglish)
             {
                 filters.Add(new EnglishFilter());
+            }
+            if (filterConfig.IgnoreFirstCJK)
+            {
+                filters.Add(new FirstCJKFilter());
             }
             var lenFilter = new LengthFilter();
             lenFilter.MinLength = filterConfig.WordLengthFrom;
@@ -613,7 +619,13 @@ namespace Studyzy.IMEWLConverter
             }
             else if (mergeTo1File)
             {
-                richTextBox1.Text = fileContent;
+                if (toolStripMenuItemShowLess.Checked && (fileContent.Length > 200000))
+                {
+                    richTextBox1.Text = "为避免输出时卡死，“高级设置”中选中了“结果只显示首、末10万字”，本文本框中不显示转换后的全部结果，若要查看转换后的结果再确定是否保存请取消该设置。\n\n"
+                     + fileContent.Substring(0, 100000) + "\n\n\n...\n\n\n"+  fileContent.Substring(fileContent.Length - 100000);
+                }
+                else
+                     richTextBox1.Text = fileContent;
                 //btnExport.Enabled = true;
             }
             if (!mergeTo1File || export is Win10MsPinyin || export is Win10MsWubi || export is Win10MsPinyinSelfStudy || export is Gboard)//微软拼音是二进制文件，不需要再提示保存

--- a/src/IME WL Converter Win/IME WL Converter Win.csproj
+++ b/src/IME WL Converter Win/IME WL Converter Win.csproj
@@ -107,7 +107,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Windows.Forms">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6\System.Windows.Forms.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ImeWlConverterCore/Entities/FilterConfig.cs
+++ b/src/ImeWlConverterCore/Entities/FilterConfig.cs
@@ -27,9 +27,11 @@ namespace Studyzy.IMEWLConverter.Entities
             WordRankTo = 999999;
             WordRankPercentage = 100;
             IgnoreFirstCJK = true;
-       //     ReplaceSpace = true;
-       //     ReplacePunctuation = true;
-       //     ReplaceNumber = true;
+            //     ReplaceSpace = true;
+            //     ReplacePunctuation = true;
+            //     ReplaceNumber = true;
+            KeepSpace_ = true;
+            KeepSpace = true;
             NoFilter = false;
             KeepEnglish = true;
             KeepNumber_ = true;
@@ -64,7 +66,8 @@ namespace Studyzy.IMEWLConverter.Entities
         public bool KeepPunctuation_ { get; set; }
         public bool ChsNumber { get; set; }
         public bool PrefixEnglish { get; set; }
-
+        public bool KeepSpace_ { get; set; }
+        public bool KeepSpace { get; set; }
         public bool needEnglishTag() { return PrefixEnglish; }
     }
 }

--- a/src/ImeWlConverterCore/Entities/FilterConfig.cs
+++ b/src/ImeWlConverterCore/Entities/FilterConfig.cs
@@ -26,14 +26,19 @@ namespace Studyzy.IMEWLConverter.Entities
             WordRankFrom = 1;
             WordRankTo = 999999;
             WordRankPercentage = 100;
-            IgnoreEnglish = true;
-            IgnoreSpace = true;
-            IgnorePunctuation = true;
-            IgnoreNumber = true;
+            IgnoreFirstCJK = true;
+       //     ReplaceSpace = true;
+       //     ReplacePunctuation = true;
+       //     ReplaceNumber = true;
             NoFilter = false;
+            KeepEnglish = true;
+            KeepNumber_ = true;
+            PrefixEnglish = true;
+            KeepPunctuation_ = true;
         }
 
         public bool NoFilter { get; set; }
+        public bool KeepEnglish { get;  set; }
         public int WordLengthFrom { get; set; }
         public int WordLengthTo { get; set; }
 
@@ -51,5 +56,15 @@ namespace Studyzy.IMEWLConverter.Entities
         public bool ReplaceEnglish { get; set; }
         public bool ReplaceSpace { get; set; }
         public bool ReplacePunctuation { get; set; }
+        public bool KeepNumber { get; set; }
+        public bool IgnoreFirstCJK { get; set; }
+        public bool KeepNumber_ { get; set; }
+        public bool KeepEnglish_ { get; set; }
+        public bool KeepPunctuation { get; set; }
+        public bool KeepPunctuation_ { get; set; }
+        public bool ChsNumber { get; set; }
+        public bool PrefixEnglish { get; set; }
+
+        public bool needEnglishTag() { return PrefixEnglish; }
     }
 }

--- a/src/ImeWlConverterCore/Filters/FirstCJKFilter.cs
+++ b/src/ImeWlConverterCore/Filters/FirstCJKFilter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using System.Text.RegularExpressions;
+using Studyzy.IMEWLConverter.Entities;
+
+namespace Studyzy.IMEWLConverter.Filters
+{
+    /// <summary>
+    ///     过滤首字符非中日韩的词（实际上非常粗糙）
+    /// </summary>
+    public class FirstCJKFilter : ISingleFilter
+    {
+        public bool ReplaceAfterCode => false;
+
+        public bool IsKeep(WordLibrary wl)
+        {
+            char c = wl.Word[0];
+            return c >= 0x2e80 && c <= 0x9fff;
+        }
+    }
+}

--- a/src/ImeWlConverterCore/MainBody.cs
+++ b/src/ImeWlConverterCore/MainBody.cs
@@ -503,9 +503,11 @@ namespace Studyzy.IMEWLConverter
                 return;
             countWord = wordLibraryList.Count;
             currentStatus = 0;
-            Regex numberRegex = new Regex("[0-9]+", RegexOptions.IgnoreCase);
-            Regex englishRegex = new Regex("[a-zA-Z]+", RegexOptions.IgnoreCase);
-            Regex punctuationRegex = new Regex("[-・·&%']", RegexOptions.IgnoreCase);
+            Regex spaceRegex = new Regex("(?=[^a-zA-Z])\\s+");
+            Regex numberRegex = new Regex("[0-9]+");
+            Regex englishRegex = new Regex("[a-z]+", RegexOptions.IgnoreCase);
+           // Regex punctuationRegex = new Regex("[-・·&%']");
+            Regex punctuationRegex = new Regex("[\u0021-\u002f\u003a-\u0040\u005b-\u0060\u007b-\u008f\u00d7\u00f7\u2000-\u2bff\u3000-\u303f]");
 
 
             foreach (WordLibrary wordLibrary in wordLibraryList)
@@ -533,6 +535,15 @@ namespace Studyzy.IMEWLConverter
                     if (FilterConfig.KeepEnglish_)
                     {
                         word = englishRegex.Replace(word, "");
+                    }
+
+                    if (FilterConfig.KeepSpace_)
+                    {
+                        if (FilterConfig.KeepSpace == false)
+                            word = word.Replace(" ", "");
+                        else
+                            word = spaceRegex.Replace(word, "");
+
                     }
 
                     if (FilterConfig.KeepPunctuation_)
@@ -567,10 +578,15 @@ namespace Studyzy.IMEWLConverter
                             else if (c >= 0x61 && c <= 0x7a)
                             {
                                 type = 2;
-                            }
-                            else if (" - ・ &  %  '".Contains(c))
+                            }else if (c == 0x20 && FilterConfig.KeepSpace && clipType==2)
                             {
-
+                                type = 2;
+                            }
+                            else if ("-・&%'".Contains(c))
+                            {
+                                type = 3;
+                            }else if (punctuationRegex.IsMatch(c.ToString()))
+                            {
                                 type = 3;
                             }
                             else

--- a/src/ImeWlConverterCore/MainBody.cs
+++ b/src/ImeWlConverterCore/MainBody.cs
@@ -507,7 +507,7 @@ namespace Studyzy.IMEWLConverter
             Regex numberRegex = new Regex("[0-9]+");
             Regex englishRegex = new Regex("[a-z]+", RegexOptions.IgnoreCase);
            // Regex punctuationRegex = new Regex("[-・·&%']");
-            Regex punctuationRegex = new Regex("[\u0021-\u002f\u003a-\u0040\u005b-\u0060\u007b-\u008f\u00d7\u00f7\u2000-\u2bff\u3000-\u303f]");
+            Regex punctuationRegex = new Regex("[\u0021-\u002f\u003a-\u0040\u005b-\u0060\u007b-\u008f\u00a0-\u00bf\u00d7\u00f7\u2000-\u2bff\u3000-\u303f\u30a0\u30fb]");
 
 
             foreach (WordLibrary wordLibrary in wordLibraryList)

--- a/src/ImeWlConverterCore/MainBody.cs
+++ b/src/ImeWlConverterCore/MainBody.cs
@@ -27,10 +27,11 @@ using Studyzy.IMEWLConverter.Helpers;
 using Studyzy.IMEWLConverter.Language;
 using System.Linq;
 using System.Timers;
+using System.Text.RegularExpressions;
 
 namespace Studyzy.IMEWLConverter
 {
-    public class MainBody:IDisposable
+    public class MainBody : IDisposable
     {
         public event Action<string> ProcessNotice;
         private WordLibraryList allWlList = new WordLibraryList();
@@ -47,7 +48,7 @@ namespace Studyzy.IMEWLConverter
         private Timer timer;
 
 
-        public IList<string> ExportContents { get; set; } 
+        public IList<string> ExportContents { get; set; }
         public MainBody()
         {
             Filters = new List<ISingleFilter>();
@@ -169,6 +170,8 @@ namespace Studyzy.IMEWLConverter
 
         public IList<IReplaceFilter> ReplaceFilters { get; set; }
 
+        public FilterConfig FilterConfig { get; set; }
+
         public IList<ISingleFilter> Filters { get; set; }
         public SortType SortType { get; set; }
         public bool SortDesc { get; set; }
@@ -266,9 +269,10 @@ namespace Studyzy.IMEWLConverter
             //}
             ExportContents = export.Export(allWlList);
 
-
             this.timer.Stop();
+
             return string.Join("\r\n", ExportContents.ToArray());
+
         }
 
         private WordLibraryList RemoveEmptyCodeData(WordLibraryList wordLibraryList)
@@ -291,7 +295,7 @@ namespace Studyzy.IMEWLConverter
             currentStatus = 0;
             foreach (WordLibrary wordLibrary in wordLibraryList)
             {
-                if (wordLibrary.Rank == 0|| wordRankGenerater.ForceUse )
+                if (wordLibrary.Rank == 0 || wordRankGenerater.ForceUse)
                 {
                     wordLibrary.Rank = wordRankGenerater.GetRank(wordLibrary.Word);
                 }
@@ -299,11 +303,198 @@ namespace Studyzy.IMEWLConverter
                 processMessage = "生成词频：" + currentStatus + "/" + countWord;
             }
         }
+        /// 把字符串中的数字转换为汉字. 当数字不以0开头，并且以多个0结尾时，按照x千x百的方式转换。否则直接读挨个数字。
+        private String TranslateChineseNumber(String str)
+        {
+            StringBuilder builder = new StringBuilder();
+            StringBuilder buffer = new StringBuilder();
+
+            foreach (Char c in str)
+            {
+                if (c <= '9' && c >= '0')
+                {
+                    buffer.Append(c);
+                }
+                else
+                {
+                    if (buffer.Length > 0)
+                    {
+                        builder.Append(Num2Chs(buffer.ToString()));
+                        buffer = new StringBuilder();
+                    }
+                    builder.Append(c);
+                }
+            }
+
+            if (buffer.Length > 0)
+                builder.Append(Num2Chs(buffer.ToString()));
+
+            return builder.ToString();
+        }
+
+        private String Num2Chs(String str)
+        {
+            Regex regex = new Regex("[1-9].+(0{2,100})");
+            if (regex.IsMatch(str))
+                return Int2Chs(long.Parse(str));
+
+            Char[] chars = new Char[str.Length];
+
+            for (int i = 0; i < str.Length; i++)
+            {
+                chars[i] = Num2Char(str[i]);
+            }
+
+            return new String(chars);
+
+        }
+
+        private char Num2Char(Char c)
+        {
+            switch (c)
+            {
+                case '1':
+                    return '一';
+                case '2':
+                    return '二';
+                case '3':
+                    return '三';
+                case '4':
+                    return '四';
+                case '5':
+                    return '五';
+                case '6':
+                    return '六';
+                case '7':
+                    return '七';
+                case '8':
+                    return '八';
+                case '9':
+                    return '九';
+            }
+            return '零';
+        }
+
+        // 十位以上的数字转换汉字, 来自这里 https://blog.csdn.net/iplayvs2008/article/details/89517321
+        private static string Int2Chs(long input)
+        {
+            string ret = null;
+            long input2 = Math.Abs(input);
+            string resource = "零一二三四五六七八九";
+            string unit = "个十百千万亿兆京垓秭穰沟涧正载极";
+            if (input > Math.Pow(10, 4 * (unit.Length - unit.IndexOf('万'))))
+            {
+                throw new Exception("the input is too big,input:" + input);
+            }
+            Func<long, List<List<int>>> splitNumFunc = (val) =>
+            {
+                int i = 0;
+                int mod;
+                long val_ = val;
+                List<List<int>> splits = new List<List<int>>();
+                List<int> splitNums;
+                do
+                {
+                    mod = (int)(val_ % 10);
+                    val_ /= 10;
+                    if (i % 4 == 0)
+                    {
+                        splitNums = new List<int>();
+                        splitNums.Add(mod);
+                        if (splits.Count == 0)
+                        {
+                            splits.Add(splitNums);
+                        }
+                        else
+                        {
+                            splits.Insert(0, splitNums);
+                        }
+                    }
+                    else
+                    {
+                        splitNums = splits[0];
+                        splitNums.Insert(0, mod);
+                    }
+                    i++;
+                } while (val_ > 0);
+                return splits;
+            };
+            Func<List<List<int>>, string> hommizationFunc = (data) =>
+            {
+                List<StringBuilder> builders = new List<StringBuilder>();
+                for (int i = 0; i < data.Count; i++)
+                {
+                    List<int> data2 = data[i];
+                    StringBuilder newVal = new StringBuilder();
+                    for (int j = 0; j < data2.Count;)
+                    {
+                        if (data2[j] == 0)
+                        {
+                            int k = j + 1;
+                            for (; k < data2.Count && data2[k] == 0; k++) ;
+                            //个位不是0，前面补一个零
+                            newVal.Append('零');
+                            j = k;
+                        }
+                        else
+                        {
+                            newVal.Append(resource[data2[j]]).Append(unit[data2.Count - 1 - j]);
+                            j++;
+                        }
+                    }
+                    if (newVal[newVal.Length - 1] == '零' && newVal.Length > 1)
+                    {
+                        newVal.Remove(newVal.Length - 1, 1);
+                    }
+                    else if (newVal[newVal.Length - 1] == '个')
+                    {
+                        newVal.Remove(newVal.Length - 1, 1);
+                    }
+
+                    if (i == 0 && newVal.Length > 1 && newVal[0] == '一' && newVal[1] == '十')
+                    {//一十 --> 十
+                        newVal.Remove(0, 1);
+                    }
+                    builders.Add(newVal);
+                }
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < builders.Count; i++)
+                {//拼接
+                    if (builders.Count == 1)
+                    {//个位数
+                        sb.Append(builders[i]);
+                    }
+                    else
+                    {
+                        if (i == builders.Count - 1)
+                        {//万位以下的
+                            if (builders[i][builders[i].Length - 1] != '零')
+                            {//十位以上的不拼接"零"
+                                sb.Append(builders[i]);
+                            }
+                        }
+                        else
+                        {//万位以上的
+                            if (builders[i][0] != '零')
+                            {//零万零亿之类的不拼接
+                                sb.Append(builders[i]).Append(unit[unit.IndexOf('千') + builders.Count - 1 - i]);
+                            }
+                        }
+                    }
+                }
+                return sb.ToString();
+            };
+            List<List<int>> ret_split = splitNumFunc(input2);
+            ret = hommizationFunc(ret_split);
+            if (input < 0) ret = "-" + ret;
+            return ret;
+        }
+
 
         private void GenerateDestinationCode(WordLibraryList wordLibraryList, CodeType codeType)
         {
             if (wordLibraryList.Count == 0) return;
-            if(wordLibraryList[0].CodeType== CodeType.NoCode&& codeType == CodeType.UserDefinePhrase)
+            if (wordLibraryList[0].CodeType == CodeType.NoCode && codeType == CodeType.UserDefinePhrase)
             {
                 codeType = CodeType.Pinyin;
             }
@@ -312,6 +503,11 @@ namespace Studyzy.IMEWLConverter
                 return;
             countWord = wordLibraryList.Count;
             currentStatus = 0;
+            Regex numberRegex = new Regex("[0-9]+", RegexOptions.IgnoreCase);
+            Regex englishRegex = new Regex("[a-zA-Z]+", RegexOptions.IgnoreCase);
+            Regex punctuationRegex = new Regex("[-・·&%']", RegexOptions.IgnoreCase);
+
+
             foreach (WordLibrary wordLibrary in wordLibraryList)
             {
                 currentStatus++;
@@ -327,11 +523,143 @@ namespace Studyzy.IMEWLConverter
                 }
                 try
                 {
-                    generater.GetCodeOfWordLibrary(wordLibrary);
+                    string word_0 = wordLibrary.Word;
+                    string word = wordLibrary.Word;
+                    if (FilterConfig.KeepNumber_)
+                    {
+                        word = numberRegex.Replace(word, "");
+                    }
+
+                    if (FilterConfig.KeepEnglish_)
+                    {
+                        word = englishRegex.Replace(word, "");
+                    }
+
+                    if (FilterConfig.KeepPunctuation_)
+                    {
+                        word = punctuationRegex.Replace(word, "");
+                    }
+
+                    if (FilterConfig.ChsNumber)
+                    {
+                        word = TranslateChineseNumber(word);
+                    }
+
+                    if ((englishRegex.IsMatch(word) && FilterConfig.KeepEnglish) || (numberRegex.IsMatch(word) && FilterConfig.KeepNumber) || (punctuationRegex.IsMatch(word) && FilterConfig.KeepPunctuation))
+                    {
+
+                        StringBuilder input = new StringBuilder();
+                        List<IList<string>> output = new List<IList<string>>();
+
+                        int clipType = -1; int type = 0;
+
+                        foreach (char c in word)
+                        {
+
+                            if (c >= 0x30 && c <= 0x39)
+                            {
+                                type = 1;
+                            }
+                            else if (c >= 0x41 && c <= 0x5a)
+                            {
+                                type = 2;
+                            }
+                            else if (c >= 0x61 && c <= 0x7a)
+                            {
+                                type = 2;
+                            }
+                            else if (" - ・ &  %  '".Contains(c))
+                            {
+
+                                type = 3;
+                            }
+                            else
+                            {
+                                type = 0;
+                            }
+                            if (input.Length < 1)
+                            {
+                                clipType = type;
+                                input.Append(c);
+                            }
+                            else if (type == clipType)
+                            {
+                                input.Append(c);
+                            }
+
+                            else
+                            {
+
+                                if (clipType == 2 && FilterConfig.KeepEnglish)
+                                {
+                                    if (FilterConfig.needEnglishTag())
+                                        output.Add(new List<string> { '_' + input.ToString() });
+                                    else
+                                        output.Add(new List<string> { input.ToString() });
+
+                                }
+                                else if ((clipType == 1 && FilterConfig.KeepNumber) || (clipType == 3 && FilterConfig.KeepPunctuation))
+                                {
+                                    output.Add(new List<string> { input.ToString() });
+                                }
+                                else
+                                {
+                                    wordLibrary.Word = input.ToString();
+                                    wordLibrary.CodeType = CodeType.NoCode;
+                                    generater.GetCodeOfWordLibrary(wordLibrary);
+                                    output.AddRange(wordLibrary.Codes);
+                                }
+                                input.Clear();
+                                input.Append(c);
+                                clipType = type;
+
+                            }
+                        }
+
+                        if (input.Length > 0)
+                        {
+                            if (clipType == 2 && FilterConfig.KeepEnglish)
+                            {
+                                if (FilterConfig.needEnglishTag())
+                                    output.Add(new List<string> { '_' + input.ToString() });
+                                else
+                                    output.Add(new List<string> { input.ToString() });
+
+                            }
+                            else if ((clipType == 1 && FilterConfig.KeepNumber) || (clipType == 3 && FilterConfig.KeepPunctuation))
+                            {
+                                output.Add(new List<string> { input.ToString() });
+                            }
+                            else
+                            {
+                                wordLibrary.Word = input.ToString();
+                                wordLibrary.CodeType = CodeType.NoCode;
+                                generater.GetCodeOfWordLibrary(wordLibrary);
+                                output.AddRange(wordLibrary.Codes);
+                            }
+                        }
+
+                        wordLibrary.Word = word_0;
+                        wordLibrary.Codes = new Code(output);
+
+                    }
+                    else
+                    {
+                        if (word.Equals(word_0))
+                            generater.GetCodeOfWordLibrary(wordLibrary);
+                        else
+                        {
+                            wordLibrary.Word = word;
+                            generater.GetCodeOfWordLibrary(wordLibrary);
+                            wordLibrary.Word = word_0;
+
+                        }
+                    }
+
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine("生成编码失败"+ex.Message);
+                    Debug.WriteLine("生成编码失败" + ex.Message);
                 }
                 if (codeType != CodeType.Unknown)
                     wordLibrary.CodeType = codeType;
@@ -346,7 +674,7 @@ namespace Studyzy.IMEWLConverter
         public void Convert(IList<string> filePathes, string outputDir)
         {
             this.timer.Start();
-            ExportContents=new List<string>();
+            ExportContents = new List<string>();
             int c = 0;
 
             //filePathes = GetRealPath(filePathes);
@@ -366,7 +694,7 @@ namespace Studyzy.IMEWLConverter
                     }
                     c += wlList.Count;
                     GenerateWordRank(wlList);
-                    wlList= RemoveEmptyCodeData(wlList);
+                    wlList = RemoveEmptyCodeData(wlList);
                     ReplaceAfterCode(wlList);
                     ExportContents = export.Export(wlList);
                     for (var i = 0; i < ExportContents.Count; i++)


### PR DESCRIPTION
1. 主界面菜单增加选项：“结果只显示首、末10万字符”，当词库较大时，既能预览转换结果，也能避免输出到文本框的内容过多导致程序卡死
2. 在词条过滤设置增加选项： 首字为cjk字符
3. 在词条过滤设置界面增加词条分段处理选项组：当词条包含字母、数字、标点时，可以选择保留原字符编码或者不编码。特别地，数字可以转换为中文读法（算法本身比较粗糙， 当数字不以0开头，并且以多个0结尾时，按照x千x百的方式转换；否则直接读挨个数字），英语可以在编码前方添加"_"标记与汉字做区分。
4.  增加的功能目前都只能在图形界面设置，未实现命令行界面的接口。