### PR TITLE
add: 添加输入Rime userdb.txt用户词典, 已测试gboard, google 拼音, 搜狗txt输出正常

### DIFF
--- a/src/ImeWlConverterCore/ConstantString.cs
+++ b/src/ImeWlConverterCore/ConstantString.cs
@@ -67,6 +67,7 @@ namespace Studyzy.IMEWLConverter
         public const string XIAOXIAO_ERBI = "二笔输入法";
         public const string FIT = "FIT输入法";
         public const string RIME = "Rime中州韵";
+        public const string RIME_USERDB = "Rime UserDb 用户词典";
         public const string CANGJIE_PLATFORM = "仓颉平台";
         public const string BING_PINYIN = "必应输入法";
         public const string LINGOES_LD2 = "灵格斯ld2";

--- a/src/ImeWlConverterCore/IME/RimeUserDb.cs
+++ b/src/ImeWlConverterCore/IME/RimeUserDb.cs
@@ -1,0 +1,194 @@
+﻿/*
+ *   Copyright © 2009-2020 studyzy(深蓝,曾毅)
+
+ *   This program "IME WL Converter(深蓝词库转换)" is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Studyzy.IMEWLConverter.Entities;
+using Studyzy.IMEWLConverter.Generaters;
+using Studyzy.IMEWLConverter.Helpers;
+
+namespace Studyzy.IMEWLConverter.IME
+{
+    /// <summary>
+    /// RIME是一个输入法框架，支持多种输入法编码，词库规则是：
+    /// 词语+Tab+编码（拼音空格隔开）+Tab+词频
+    /// 
+    /// </summary>
+    [ComboBoxShow(ConstantString.RIME_USERDB, ConstantString.RIME_C, 150)]
+    public class RimeUserDb : BaseTextImport, IWordLibraryTextImport, IWordLibraryExport, IMultiCodeType
+    {
+        private string lineSplitString;
+        public RimeUserDb()
+        {
+            CodeType = CodeType.Pinyin;
+            OS = OperationSystem.Windows;
+        }
+
+        private OperationSystem os;
+
+        public OperationSystem OS
+        {
+            get { return os; }
+            set
+            {
+                os = value;
+                lineSplitString = GetLineSplit(os);
+            }
+        }
+
+        private string GetLineSplit(OperationSystem os)
+        {
+            switch (os)
+            {
+                case OperationSystem.Windows:
+                    return "\r\n";
+
+                case OperationSystem.MacOS:
+                    return "\r";
+
+                case OperationSystem.Linux:
+                    return "\n";
+            }
+            return "\r\n";
+        }
+
+        #region IWordLibraryExport 成员
+
+        private IWordCodeGenerater codeGenerater;
+        //private RimeConfigForm form;
+
+        public string ExportLine(WordLibrary wl)
+        {
+            var sb = new StringBuilder();
+            if (this.CodeType == wl.CodeType&&this.CodeType!= CodeType.Pinyin&&CodeType!=CodeType.TerraPinyin)
+            {
+                return wl.Word + "\t" + wl.Codes[0][0] + "\t" + wl.Rank;
+            }
+
+            if (codeGenerater == null)
+            {
+                codeGenerater = CodeTypeHelper.GetGenerater(CodeType);
+            }
+            try
+            {
+                codeGenerater.GetCodeOfWordLibrary(wl);
+            }
+            catch (Exception ex)
+            {
+                Debug.Fail(ex.Message);
+                return null;
+            }
+           
+
+            if (codeGenerater.Is1CharMutiCode)
+            {
+                IList<string> codes = codeGenerater.GetCodeOfString(wl.Word).ToCodeString(" ");
+                int i = 0;
+                foreach (string code in codes)
+                {
+                    sb.Append(wl.Word);
+                    sb.Append("\t");
+                    sb.Append(code);
+                    sb.Append("\t");
+                    sb.Append(wl.Rank);
+                    i++;
+                    if (i != codes.Count)
+                        sb.Append(lineSplitString);
+                }
+            }
+            else
+            {
+                sb.Append(wl.Word);
+                sb.Append("\t");
+                if (CodeType == CodeType.Pinyin || CodeType == CodeType.TerraPinyin)
+                {
+                    sb.Append(wl.GetPinYinString(" ", BuildType.None));
+                }
+                else if (CodeType == wl.CodeType)
+                {
+                    sb.Append(wl.Codes[0][0]);
+                }
+                else
+                {
+
+                    sb.Append(wl.Codes.ToCodeString(" ")[0]);
+                }
+                sb.Append("\t");
+                sb.Append(wl.Rank);
+            }
+            return sb.ToString();
+        }
+
+
+        public IList<string> Export(WordLibraryList wlList)
+        {
+            codeGenerater = CodeTypeHelper.GetGenerater(CodeType);
+            var sb = new StringBuilder();
+            for (int i = 0; i < wlList.Count; i++)
+            {
+                var line = ExportLine(wlList[i]);
+                if (!string.IsNullOrEmpty(line))
+                {
+                    sb.Append(line);
+                    sb.Append(lineSplitString);
+                }
+            }
+            return new List<string>() { sb.ToString() };
+        }
+
+        public override Encoding Encoding
+        {
+            get { return new UTF8Encoding(false); }
+        }
+
+        #endregion
+
+        #region IWordLibraryImport 成员
+
+
+        //private IWordCodeGenerater pyGenerater=new PinyinGenerater();
+        public override WordLibraryList ImportLine(string line)
+        {
+            string[] lineArray = line.Split('\t');
+
+            string code = lineArray[0];
+            string word = lineArray[1];
+            var wl = new WordLibrary();
+            wl.Word = word;
+            // userdb.txt 的词频不通用, 注释掉
+            // wl.Rank = Convert.ToInt32(lineArray[2]);
+            if (CodeType == CodeType.Pinyin)
+            {
+                wl.PinYin = code.Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                //wl.PinYin = CollectionHelper.ToArray(pyGenerater.GetCodeOfString(wl.Word));
+                wl.SetCode(CodeType, code);
+            }
+
+
+            var wll = new WordLibraryList();
+            wll.Add(wl);
+            return wll;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## 功能添加

解决rime的用户词典无法转其他词库的功能缺失问题

## 处理逻辑

以 xxx.userdb.txt 输入, dictionary.txt 输出为例:

### 输入: xxx.userdb.txt

```
# Rime user dictionary
#@/db_name	luna_pinyin.userdb
#@/db_type	userdb
#@/rime_version	1.5.3
#@/tick	51207
#@/user_id	rime-xxx
a 	啊	c=194 d=2.84851 t=51207
a 	阿	c=0 d=0.0527292 t=51207
a gen ting 	阿根廷	c=2 d=0.00211643 t=51207
```

### 输出: dictionary.txt

```
# Gboard Dictionary version:1
a	啊	zh-CN
a	阿	zh-CN
agenting	阿根廷	zh-CN
```